### PR TITLE
Fix default value in CI to PDO driver mapping

### DIFF
--- a/agendav.php
+++ b/agendav.php
@@ -51,7 +51,7 @@ class agendav extends rcube_plugin
             case 'postgre':
                 return 'pgsql';
             default:
-                return $db[$active_group]['dbdriver'];
+                return $rcmail->config->get('agendav_dbtype', false);
         }
     }
 


### PR DESCRIPTION
Function get_db_driver maps CI DB driver name to PDO (commit 3e90a3b9).
Default return value is: `$db[$active_group]['dbdriver']`.
Neither `$db` nor `$active_group` is defined inside `get_db_driver`.
They are defined in AgenDAV config file and then referenced by plugin configuration:
`$config['agendav_dbtype'] = $db[$active_group]['dbdriver'];`
Therefore default return value should be the `'agendav_dbtype'` key from plugin configuration.
